### PR TITLE
Support DP1 object catalog in ACO360_WL_HSCcalib_MassMap

### DIFF
--- a/ACO360_WL_HSCcalib_MassMap.ipynb
+++ b/ACO360_WL_HSCcalib_MassMap.ipynb
@@ -40,7 +40,8 @@
     "# general python packages\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from astropy.table import Table"
    ]
   },
   {
@@ -62,9 +63,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "repo = '/repo/main'\n",
-    "collection = 'LSSTComCam/runs/DRP/DP1/w_2025_08/DM-49029'\n",
-    "butler = Butler(repo, collections=collection)"
+    "repo = \"dp1\"\n",
+    "collection = \"LSSTComCam/DP1\"\n",
+    "#repo = '/repo/main'\n",
+    "#collection = 'LSSTComCam/runs/DRP/DP1/w_2025_08/DM-49029'\n",
+    "\n",
+    "butler = Butler(repo, collections=collection)\n",
+    "assert butler is not None"
    ]
   },
   {
@@ -139,11 +144,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "141d1ef1-6b25-4e1a-9a27-0211cdc5a1a8",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "# Get the object catlaog of these patches\n",
-    "datasetType = 'objectTable'\n",
+    "# Get the object catalog of these patches\n",
+    "datasetType = 'object'  # for DP1 object catalogs\n",
+    "#datasetType = 'objectTable'\n",
     "#datasetType = 'deepCoadd_obj'\n",
     "merged_cat = pd.DataFrame()\n",
     "\n",
@@ -151,9 +159,18 @@
     "    print(f'Loading objects from tract {tract}, patches:{tp_dict[tract]}')\n",
     "    for patch in tp_dict[tract]:\n",
     "        dataId = {'tract': tract, 'patch' : patch ,'skymap':'lsst_cells_v1'}\n",
+    "        print(f\"Filtered patch {patch} in tract {tract}\")\n",
     "        obj_cat = butler.get(datasetType, dataId=dataId)\n",
-    "        filt = obj_cat['detect_isPrimary']==True\n",
-    "        filt &= obj_cat['r_cModel_flag']== False\n",
+    "        # obj_cat is an astropy Table in DP1. Convert to DataFrame if needed for consistent processing\n",
+    "        if isinstance(obj_cat, Table):\n",
+    "            obj_cat = obj_cat.to_pandas()\n",
+    "        elif not isinstance(obj_cat, pd.DataFrame):\n",
+    "            raise TypeError(f\"Unexpected object type: {type(obj_cat)}\")\n",
+    "\n",
+    "        # 'detect_isPrimary' not in DP1; \n",
+    "        # only 'detect_fromBlend', 'detect_isDeblendedModelSource', 'detect_isIsolated' exist\n",
+    "        #filt = obj_cat['detect_isPrimary']==True \n",
+    "        filt = obj_cat['r_cModel_flag']== False\n",
     "        filt &= obj_cat['i_cModel_flag']== False\n",
     "        filt &= obj_cat['r_cModelFlux']>0\n",
     "        filt &= obj_cat['i_cModelFlux']>0\n",
@@ -952,7 +969,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This update adds basic support for DP1 object catalogs:

- Updated 'repo' and 'collection' to use the official DP1 release (LSSTComCam/DP1)
- Added support for DP1 object catalogs by converting astropy.Table to pandas.DataFrame
- Adjusted filtering logic to match available columns in DP1
- Preserved the original processing structure for team compatibility

Note: This is a minimal update.
Memory optimization for the RSP notebook server will be addressed separately. Currently, in the cell titled *"Load the object catalogs for all these tracts/patches..."*, memory overflow occurs on the RSP server starting from patch 71 in tract 10463, which is part of a tract with many patches.